### PR TITLE
add testing of the geoip2 types; fix some compilation issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: go
+go:
+  - 1.5.1
+  - 1.4.3
+script: go test -v ./... -check.vv
+sudo: false
+notifications:
+  email:
+    on_success: never
+    on_failure: always

--- a/geoip2/types.go
+++ b/geoip2/types.go
@@ -1,72 +1,164 @@
+// Package geoip2 provides types and functions to work with the MaxMind
+// GeoIP2 Web Services API.
+//
+// As of writing only the data structures have been implemented as they are
+// neded for the github.com/theckman/go-maxmind/minfraud package.
 package geoip2
 
+// Names is a struct to compose reused fields in to other structs.
 type Names struct {
-	GeonameID float64           `json:"geoname_id,omitempty"`
-	Names     map[string]string `json:"names,omitempty"`
+	// GeonameID is a unique identifier for the city as specified
+	// by GeoNames: http://www.geonames.org/
+	GeonameID float64 `json:"geoname_id,omitempty"`
+
+	// Names is a map from locale codes, such as "en", to localized
+	// names for the item.
+	Names map[string]string `json:"names,omitempty"`
 }
 
+// City contains details about the city associated with the IP address.
 type City struct {
 	Names
+
+	// Confidence is a value from 0-100 representing MaxMind's confidence
+	// that the city is correct.
 	Confidence float64 `json:"confidence,omitempty"`
 }
 
+// Continent contains information about the continent associated with the
+// IP address.
 type Continent struct {
 	Names
-	Code GeoIP2ContinentCode `json:"code,omitempty"`
+
+	// Code is the ContinentCode associated with the IP address. The
+	// ContinentCode type automatically converts the value to and from the
+	// two-letter code used by the MaxMind API.
+	Code ContinentCode `json:"code,omitempty"`
 }
 
+// Country contains details about the country where MaxMind believes the
+// end user is located.
 type Country struct {
 	Names
+
+	// Confidence is a value from 0-100 representing MaxMind's confidence
+	// that the country is correct.
 	Confidence float64 `json:"confidence,omitempty"`
-	ISOCode    string  `json:"iso_code,omitempty"` // ISO 3166-1
+
+	// ISOCode is a two-character ISO 3166-1 country code for the country
+	// associated with the IP address.
+	ISOCode string `json:"iso_code,omitempty"`
 }
 
+// Location contains specific details about the location associated with
+// the IP address.
 type Location struct {
-	AccuracyRadius    float64 `json:"accuracy_radius,omitempty"`
-	AverageIncome     float64 `json:"average_income,omitempty"`
-	Latitude          float64 `json:"latitude,omitempty"`
-	Longitude         float64 `json:"longitude,omitempty"`
-	MetroCode         float64 `json:"metro_code,omitempty"`
+	// AccuracyRadius is the radius in kilometers around the specified
+	// location where the IP address is likely to be.
+	AccuracyRadius float64 `json:"accuracy_radius,omitempty"`
+
+	// AverageIncome is the average income associated with the IP address.
+	AverageIncome float64 `json:"average_income,omitempty"`
+
+	// Latitude is the latitude of the location associated with the IP address.
+	Latitude float64 `json:"latitude,omitempty"`
+
+	// Longitude is the longitude of the location associated with the IP address.
+	Longitude float64 `json:"longitude,omitempty"`
+
+	// MetroCode is the metro code associated with the IP address. These are
+	// only available for IP addresses in the US. MaxMind returns the same
+	// metro codes as the Google AdWords API.
+	MetroCode float64 `json:"metro_code,omitempty"`
+
+	// PopulationDensity is the estimated number of people per square kilometer.
 	PopulationDensity float64 `json:"population_density,omitempty"`
-	TimeZone          string  `json:"time_zone,omitempty"`
+
+	// TimeZone is the time zone associated with location, as specified by the,
+	// IANA Time Zone Database, e.g. "America/New_York".
+	TimeZone string `json:"time_zone,omitempty"`
 }
 
+// Postal contains details about the postal code associated with the IP address.
 type Postal struct {
-	Code       string  `json:"code,omitempty"`
+	// Code is the postal code associated with the IP address. These are
+	// available for some IP addresses in Australia, Canada, France, Germany,
+	// Italy, Spain, Switzerland, United Kingdom, and the US. MaxMind returns
+	// the first 3 characters for Canadian postal codes. We return the the
+	// first 2-4 characters (outward code) for postal codes in the United Kingdom.
+	Code string `json:"code,omitempty"`
+
+	// Confidence is the value from 0-100 representing MaxMind's confidence that
+	// the postal code is correct.
 	Confidence float64 `json:"confidence,omitempty"`
 }
 
+// RegisteredCountry contains details about the country in which the ISP has
+// registered the IP address.
 type RegisteredCountry struct {
 	Names
-	ISOCode string `json:"iso_code,omitempty"` // ISO 3166-1
+
+	// ISOCode is a two-character ISO 3166-1 country code for the country
+	// associated with the IP address.
+	ISOCode string `json:"iso_code,omitempty"`
 }
 
+// RepresentedCountry contains details about the country which is represented
+// by users of the IP address. For instance, the country represented by an
+// overseas military base.
 type RepresentedCountry struct {
 	Names
-	ISOCode string `json:"iso_code,omitempty"` // ISO 3166-1
-	Type    string `json:"type,omitempty"`
+
+	// ISOCode is a two-character ISO 3166-1 country code for the country
+	// associated with the IP address.
+	ISOCode string `json:"iso_code,omitempty"`
+
+	// Type is the type of represented country. Currently limited to military
+	// but may include other types in the future.
+	Type string `json:"type,omitempty"`
 }
 
-type Subdivisions struct {
+// Subdivision contains details about a subdivision of the country in which the
+// IP address resides.
+type Subdivision struct {
 	Names
 	Confidence float64 `json:"confidence,omitempty"`
-	ISOCode    string  `json:"iso_code,omitempty"` // ISO 3166-1
+
+	// ISOCode is a two-character ISO 3166-1 country code for the country
+	// associated with the IP address.
+	ISOCode string `json:"iso_code,omitempty"`
 }
 
+// Traits contains general traits associated with the IP address.
 type Traits struct {
-	ASN                          float64 `json:"autonomous_system_number,omitempty"`
-	AutonomousSystemOrganization string  `json:"autonomous_system_organization,omitempty"`
-	Domain                       string  `json:"domain,omitempty"`
-	IPAddress                    string  `json:"ip_address,omitempty"`
-	ISP                          string  `json:"isp,omitempty"`
-	Organization                 string  `json:"organization,omitempty"`
-	UserType                     string  `json:"user_type,omitempty"`
+	// ASN is the Autonomous System Number associated with the IP address.
+	ASN float64 `json:"autonomous_system_number,omitempty"`
+	// AutonomousSystemOrganization is the organization associated with the
+	// registered ASN for the IP address.
+	AutonomousSystemOrganization string `json:"autonomous_system_organization,omitempty"`
+
+	// Domain is the second-level domain associated with the IP address,
+	// e.g. example.com
+	Domain string `json:"domain,omitempty"`
+
+	IPAddress    string `json:"ip_address,omitempty"`
+	ISP          string `json:"isp,omitempty"`
+	Organization string `json:"organization,omitempty"`
+
+	// UserType is the user type associated with the IP address. See the
+	// MaxMind API documentation for more information on possible types.
+	UserType string `json:"user_type,omitempty"`
 }
 
+// MaxMind contains information related to your MaxMind account.
 type MaxMind struct {
+	// QueriesRemaining is the approximate number of remaining queries
+	// available for the end point which is being called.
 	QueriesRemaining float64 `json:"queries_remaining,omitempty"`
 }
 
+// GeoIP is a struct representing the full response body of the GeoIP2 Web
+// Services API.
 type GeoIP2 struct {
 	City               *City               `json:"city,omitempty"`
 	Continent          *Continent          `json:"continent,omitempty"`
@@ -75,21 +167,53 @@ type GeoIP2 struct {
 	Postal             *Postal             `json:"postal,omitempty"`
 	RegisteredCountry  *RegisteredCountry  `json:"registered_country,omitempty"`
 	RepresentedCountry *RepresentedCountry `json:"represented_country,omitempty"`
-	Subdivisions       *Subdivisions       `json:"subdivisions,omitempty"`
-	Traits             *Traits             `json:"traits,omitempty"`
-	MaxMind            *MaxMind            `json:"maxmind,omitempty"`
+
+	// Subdivisions is a slice of *Subdivision. Each contains details about a
+	// subdivision of the country in which the IP address resides. Subdivisions
+	// are arranged from largest to smallest.
+	//
+	// For instance, the response for Oxford in the United Kingdom would have an
+	// object for England as the first element in subdivisions array and an
+	// object for Oxfordshire as the second element. The subdivisions array for
+	// Minneapolis in the United States will have a single object for Minnesota.
+	Subdivisions []*Subdivision `json:"subdivisions,omitempty"`
+
+	Traits  *Traits  `json:"traits,omitempty"`
+	MaxMind *MaxMind `json:"maxmind,omitempty"`
 }
 
+// ContinentCode is a type to easily work with the different continent codes
+// used by the MaxMind GeoIP2 Web Services API. Thie type has a Marshal and
+// Unmarshal JSON function which will automatically convert it to and from the
+// values used by the API.
+//
+// For example, if the MaxMind API responds with "EU" we convert that to
+// geoip2.ContinentEurope.
 type ContinentCode int
 
 const (
+	// ContinentUnknown is for unknown values
 	ContinentUnknown ContinentCode = iota
+
+	// ContinentAfrica is for Africa.
 	ContinentAfrica
+
+	// ContinentAntarctica is for Antarctica.
 	ContinentAntarctica
+
+	// ContinentAsia is for Asia.
 	ContinentAsia
+
+	// ContinentEurope is for Europe.
 	ContinentEurope
+
+	// ContinentNorthAmerica is for North America (and Moose).
 	ContinentNorthAmerica
+
+	// ContinentOceania is for Oceania.
 	ContinentOceania
+
+	// ContinentSouthAmerica is for South America.
 	ContinentSouthAmerica
 )
 
@@ -97,21 +221,21 @@ const (
 func (g ContinentCode) MarshalJSON() ([]byte, error) {
 	switch g {
 	case ContinentAfrica:
-		return []byte("AF"), nil
+		return []byte(`"AF"`), nil
 	case ContinentAntarctica:
-		return []byte("AN"), nil
+		return []byte(`"AN"`), nil
 	case ContinentAsia:
-		return []byte("AS"), nil
+		return []byte(`"AS"`), nil
 	case ContinentEurope:
-		return []byte("EU"), nil
+		return []byte(`"EU"`), nil
 	case ContinentNorthAmerica:
-		return []byte("NA"), nil
+		return []byte(`"NA"`), nil
 	case ContinentOceania:
-		return []byte("OC"), nil
+		return []byte(`"OC"`), nil
 	case ContinentSouthAmerica:
-		return []byte("SA"), nil
+		return []byte(`"SA"`), nil
 	default:
-		return []byte("UN"), nil
+		return []byte(`"UN"`), nil
 	}
 }
 
@@ -139,4 +263,6 @@ func (g ContinentCode) UnmarshalJSON(data []byte) error {
 			g = ContinentUnknown
 		}
 	}
+
+	return nil
 }

--- a/geoip2/types_test.go
+++ b/geoip2/types_test.go
@@ -1,0 +1,64 @@
+package geoip2
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+type TestSuite struct{}
+
+var _ = Suite(&TestSuite{})
+
+func Test(t *testing.T) { TestingT(t) }
+
+func (t *TestSuite) TestContinentCode_MarshalJSON(c *C) {
+	var cc ContinentCode
+	var j []byte
+	var err error
+
+	cc = ContinentUnknown
+	j, err = cc.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"UN"`)
+
+	cc = ContinentAfrica
+	j, err = cc.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"AF"`)
+
+	cc = ContinentAntarctica
+	j, err = cc.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"AN"`)
+
+	cc = ContinentAsia
+	j, err = cc.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"AS"`)
+
+	cc = ContinentEurope
+	j, err = cc.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"EU"`)
+
+	cc = ContinentNorthAmerica
+	j, err = cc.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"NA"`)
+
+	cc = ContinentOceania
+	j, err = cc.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"OC"`)
+
+	cc = ContinentSouthAmerica
+	j, err = cc.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"SA"`)
+
+	cc++
+	j, err = cc.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"UN"`)
+}

--- a/minfraud/event_type.go
+++ b/minfraud/event_type.go
@@ -9,7 +9,7 @@ const (
 	EventTypePurchase
 	EventTypeRecurringPurchase
 	EventTypeReferral
-	Survey
+	EventTypeSurvey
 )
 
 // MarshalJSON implements the json.Marshaler interface.

--- a/minfraud/response_types.go
+++ b/minfraud/response_types.go
@@ -46,7 +46,7 @@ type BillingAddress struct {
 }
 
 type Insights struct {
-	MinFraudScore
+	Score
 	IPAddress       *GeoIP2             `json:"ip_address,omitempty"`
 	CreditCard      *CreditCardResponse `json:"credit_card,omitempty"`
 	ShippingAddress *ShippingAddress    `json:"shipping_address,omitempty"`


### PR DESCRIPTION
This adds testing of the geoip2 package. This also fixes some issues within the `minfraud` package which prevented compilation.
