### PR TITLE
add minfraud.DeliverySpeed tests; add missing geoip2.ContinentCode test

### DIFF
--- a/geoip2/geoip2.go
+++ b/geoip2/geoip2.go
@@ -1,0 +1,6 @@
+// Package geoip2 provides types and functions to work with the MaxMind
+// GeoIP2 Web Services API.
+//
+// As of writing only the data structures have been implemented as they are
+// neded for the github.com/theckman/go-maxmind/minfraud package.
+package geoip2

--- a/geoip2/geoip2_test.go
+++ b/geoip2/geoip2_test.go
@@ -1,0 +1,13 @@
+package geoip2_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+type TestSuite struct{}
+
+var _ = Suite(&TestSuite{})
+
+func Test(t *testing.T) { TestingT(t) }

--- a/geoip2/types.go
+++ b/geoip2/types.go
@@ -1,8 +1,3 @@
-// Package geoip2 provides types and functions to work with the MaxMind
-// GeoIP2 Web Services API.
-//
-// As of writing only the data structures have been implemented as they are
-// neded for the github.com/theckman/go-maxmind/minfraud package.
 package geoip2
 
 // Names is a struct to compose reused fields in to other structs.
@@ -240,29 +235,28 @@ func (g ContinentCode) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
-func (g ContinentCode) UnmarshalJSON(data []byte) error {
+func (g *ContinentCode) UnmarshalJSON(data []byte) error {
 	if len(data) < 3 {
-		g = ContinentUnknown
+		*g = ContinentUnknown
 	} else {
 		switch string(data[1 : len(data)-1]) {
 		case "AF":
-			g = ContinentAfrica
+			*g = ContinentAfrica
 		case "AN":
-			g = ContinentAntarctica
+			*g = ContinentAntarctica
 		case "AS":
-			g = ContinentAsia
+			*g = ContinentAsia
 		case "EU":
-			g = ContinentEurope
+			*g = ContinentEurope
 		case "NA":
-			g = ContinentNorthAmerica
+			*g = ContinentNorthAmerica
 		case "OC":
-			g = ContinentOceania
+			*g = ContinentOceania
 		case "SA":
-			g = ContinentSouthAmerica
+			*g = ContinentSouthAmerica
 		default:
-			g = ContinentUnknown
+			*g = ContinentUnknown
 		}
 	}
-
 	return nil
 }

--- a/geoip2/types_test.go
+++ b/geoip2/types_test.go
@@ -1,58 +1,52 @@
-package geoip2
+package geoip2_test
 
 import (
-	"testing"
+	"github.com/theckman/go-maxmind/geoip2"
 
 	. "gopkg.in/check.v1"
 )
 
-type TestSuite struct{}
-
-var _ = Suite(&TestSuite{})
-
-func Test(t *testing.T) { TestingT(t) }
-
 func (t *TestSuite) TestContinentCode_MarshalJSON(c *C) {
-	var cc ContinentCode
+	var cc geoip2.ContinentCode
 	var j []byte
 	var err error
 
-	cc = ContinentUnknown
+	cc = geoip2.ContinentUnknown
 	j, err = cc.MarshalJSON()
 	c.Assert(err, IsNil)
 	c.Check(string(j), Equals, `"UN"`)
 
-	cc = ContinentAfrica
+	cc = geoip2.ContinentAfrica
 	j, err = cc.MarshalJSON()
 	c.Assert(err, IsNil)
 	c.Check(string(j), Equals, `"AF"`)
 
-	cc = ContinentAntarctica
+	cc = geoip2.ContinentAntarctica
 	j, err = cc.MarshalJSON()
 	c.Assert(err, IsNil)
 	c.Check(string(j), Equals, `"AN"`)
 
-	cc = ContinentAsia
+	cc = geoip2.ContinentAsia
 	j, err = cc.MarshalJSON()
 	c.Assert(err, IsNil)
 	c.Check(string(j), Equals, `"AS"`)
 
-	cc = ContinentEurope
+	cc = geoip2.ContinentEurope
 	j, err = cc.MarshalJSON()
 	c.Assert(err, IsNil)
 	c.Check(string(j), Equals, `"EU"`)
 
-	cc = ContinentNorthAmerica
+	cc = geoip2.ContinentNorthAmerica
 	j, err = cc.MarshalJSON()
 	c.Assert(err, IsNil)
 	c.Check(string(j), Equals, `"NA"`)
 
-	cc = ContinentOceania
+	cc = geoip2.ContinentOceania
 	j, err = cc.MarshalJSON()
 	c.Assert(err, IsNil)
 	c.Check(string(j), Equals, `"OC"`)
 
-	cc = ContinentSouthAmerica
+	cc = geoip2.ContinentSouthAmerica
 	j, err = cc.MarshalJSON()
 	c.Assert(err, IsNil)
 	c.Check(string(j), Equals, `"SA"`)
@@ -61,4 +55,53 @@ func (t *TestSuite) TestContinentCode_MarshalJSON(c *C) {
 	j, err = cc.MarshalJSON()
 	c.Assert(err, IsNil)
 	c.Check(string(j), Equals, `"UN"`)
+}
+
+func (t *TestSuite) TestContinentCode_UnmarshalJSON(c *C) {
+	var cc geoip2.ContinentCode
+
+	data := []byte(`""`)
+	err := cc.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(cc, Equals, geoip2.ContinentUnknown)
+
+	data = []byte(`"AF"`)
+	err = cc.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(cc, Equals, geoip2.ContinentAfrica)
+
+	data = []byte(`"AN"`)
+	err = cc.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(cc, Equals, geoip2.ContinentAntarctica)
+
+	data = []byte(`"AS"`)
+	err = cc.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(cc, Equals, geoip2.ContinentAsia)
+
+	data = []byte(`"EU"`)
+	err = cc.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(cc, Equals, geoip2.ContinentEurope)
+
+	data = []byte(`"NA"`)
+	err = cc.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(cc, Equals, geoip2.ContinentNorthAmerica)
+
+	data = []byte(`"OC"`)
+	err = cc.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(cc, Equals, geoip2.ContinentOceania)
+
+	data = []byte(`"SA"`)
+	err = cc.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(cc, Equals, geoip2.ContinentSouthAmerica)
+
+	data = []byte(`"UN"`)
+	err = cc.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(cc, Equals, geoip2.ContinentUnknown)
 }

--- a/minfraud/delivery_speed.go
+++ b/minfraud/delivery_speed.go
@@ -1,25 +1,36 @@
 package minfraud
 
+// DeliverySpeed is a helper type for the shipping delivery speed enum
+// field as part of the MinFraud Request Shipping type.
 type DeliverySpeed int
 
 const (
-	ShippingSpeedUnknown DeliverySpeed = iota
-	ShippingSameDay
-	ShippingOvernight
-	ShippingExpedited
-	ShippingStandard
+	// DeliverySpeedUnknown is for when the delivery speed is not known
+	DeliverySpeedUnknown DeliverySpeed = iota
+
+	// DeliverySpeedSameDay is for same day deliveries.
+	DeliverySpeedSameDay
+
+	// DeliverySpeedOvernight is for overnight deliveries.
+	DeliverySpeedOvernight
+
+	// DeliverySpeedExpedited is for expedited deliveries.
+	DeliverySpeedExpedited
+
+	// DeliverySpeeStandard is for standard deliveries.
+	DeliverySpeedStandard
 )
 
 // MarshalJSON implements the json.Marshaler interface.
 func (d DeliverySpeed) MarshalJSON() ([]byte, error) {
 	switch d {
-	case ShippingSameDay:
+	case DeliverySpeedSameDay:
 		return []byte(`"same_day"`), nil
-	case ShippingOvernight:
+	case DeliverySpeedOvernight:
 		return []byte(`"overnight"`), nil
-	case ShippingExpedited:
+	case DeliverySpeedExpedited:
 		return []byte(`"expedited"`), nil
-	case ShippingStandard:
+	case DeliverySpeedStandard:
 		return []byte(`"standard"`), nil
 	default:
 		return []byte(`"unknown_delivery_speed"`), nil
@@ -27,22 +38,22 @@ func (d DeliverySpeed) MarshalJSON() ([]byte, error) {
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
-func (d DeliverySpeed) UnmarshalJSON(data []byte) (err error) {
+func (d *DeliverySpeed) UnmarshalJSON(data []byte) error {
 	if len(data) < 3 {
-		d = ShippingSpeedUnknown
+		*d = DeliverySpeedUnknown
 	} else {
 		switch string(data[1 : len(data)-1]) {
 		case "same_day":
-			d = ShippingSameDay
+			*d = DeliverySpeedSameDay
 		case "overnight":
-			d = ShippingOvernight
+			*d = DeliverySpeedOvernight
 		case "expedited":
-			d = ShippingExpedited
+			*d = DeliverySpeedExpedited
 		case "standard":
-			d = ShippingStandard
+			*d = DeliverySpeedStandard
 		default:
-			d = ShippingSpeedUnknown
+			*d = DeliverySpeedUnknown
 		}
 	}
-	return
+	return nil
 }

--- a/minfraud/delivery_speed_test.go
+++ b/minfraud/delivery_speed_test.go
@@ -1,0 +1,77 @@
+package minfraud_test
+
+import (
+	"github.com/theckman/go-maxmind/minfraud"
+	. "gopkg.in/check.v1"
+)
+
+func (t *TestSuite) TestDeliverySpeed_MarshalJSON(c *C) {
+	var ds minfraud.DeliverySpeed
+	var j []byte
+	var err error
+
+	ds = minfraud.DeliverySpeedUnknown
+	j, err = ds.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"unknown_delivery_speed"`)
+
+	ds = minfraud.DeliverySpeedSameDay
+	j, err = ds.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"same_day"`)
+
+	ds = minfraud.DeliverySpeedOvernight
+	j, err = ds.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"overnight"`)
+
+	ds = minfraud.DeliverySpeedExpedited
+	j, err = ds.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"expedited"`)
+
+	ds = minfraud.DeliverySpeedStandard
+	j, err = ds.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"standard"`)
+
+	ds++
+	j, err = ds.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"unknown_delivery_speed"`)
+}
+
+func (t *TestSuite) TestDeliverySpeed_UnmarshalJSON(c *C) {
+	var ds minfraud.DeliverySpeed
+	var err error
+
+	data := []byte(`""`)
+	err = ds.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ds, Equals, minfraud.DeliverySpeedUnknown)
+
+	data = []byte(`"same_day"`)
+	err = ds.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ds, Equals, minfraud.DeliverySpeedSameDay)
+
+	data = []byte(`"overnight"`)
+	err = ds.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ds, Equals, minfraud.DeliverySpeedOvernight)
+
+	data = []byte(`"expedited"`)
+	err = ds.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ds, Equals, minfraud.DeliverySpeedExpedited)
+
+	data = []byte(`"standard"`)
+	err = ds.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ds, Equals, minfraud.DeliverySpeedStandard)
+
+	data = []byte(`"unknown_delivery_soeed"`)
+	err = ds.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ds, Equals, minfraud.DeliverySpeedUnknown)
+}

--- a/minfraud/minfraud.go
+++ b/minfraud/minfraud.go
@@ -1,0 +1,1 @@
+package minfraud

--- a/minfraud/minfraud_test.go
+++ b/minfraud/minfraud_test.go
@@ -1,0 +1,13 @@
+package minfraud_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+)
+
+type TestSuite struct{}
+
+var _ = Suite(&TestSuite{})
+
+func Test(t *testing.T) { TestingT(t) }


### PR DESCRIPTION
This adds tests for the `minfraud.DeliverySpeed` type as well as add GoDoc comments for the type.

I also missed adding a test for `geoip2.ContinentCode.UnmarshalJSON()` so I added the test for that, and fixed a bug in my implementation (yay tests!).
