### PR TITLE
add more testing and comments; add MD5Stringer type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: go
 go:
-  - 1.5.1
-  - 1.4.3
+  - 1.5.3
 script: go test -v ./... -check.vv
 sudo: false
 notifications:

--- a/minfraud/email.go
+++ b/minfraud/email.go
@@ -1,0 +1,32 @@
+// Copyright 2015-2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package minfraud
+
+import (
+	"crypto/md5"
+	"fmt"
+)
+
+// MD5Stringer is a string that contains a function to convert its value
+// to an MD5 hash of the contents. This is used by the MaxMind MinFraud
+// API for the Username and Email Address fields. This allows you to give
+// MaxMind the Username or Email in an obfuscated way. In the end it is
+// only MD5, but slightly better than plain text.
+type MD5Stringer string
+
+func (e MD5Stringer) String() string {
+	return string(e)
+}
+
+// MD5 is a function that returns the MD5 hexadecimal hash of the value.
+func (e MD5Stringer) MD5() string {
+	return fmt.Sprintf("%x", md5.Sum([]byte(string(e))))
+}
+
+// MarshalJSON is a function that implements the json.Marshaler interface.
+func (e MD5Stringer) MarshalJSON() ([]byte, error) {
+	str := fmt.Sprintf(`"%s"`, e.MD5())
+	return []byte(str), nil
+}

--- a/minfraud/email_test.go
+++ b/minfraud/email_test.go
@@ -1,0 +1,30 @@
+// Copyright 2015-2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package minfraud_test
+
+import (
+	"github.com/theckman/go-maxmind/minfraud"
+	. "gopkg.in/check.v1"
+)
+
+func (t *TestSuite) TestMD5Stringer_String(c *C) {
+	var e minfraud.MD5Stringer = "TestWord"
+	c.Check(e.String(), Equals, "TestWord")
+}
+
+func (t *TestSuite) TestMD5Stringer_MD5(c *C) {
+	var e minfraud.MD5Stringer = "These pretzels are making me thirsty."
+	c.Check(e.MD5(), Equals, "b0804ec967f48520697662a204f5fe72")
+}
+
+func (t *TestSuite) TestMD5Stringer_MarshalJSON(c *C) {
+	var b []byte
+	var err error
+	var e minfraud.MD5Stringer = "These pretzels are making me thirsty."
+
+	b, err = e.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(b), Equals, `"b0804ec967f48520697662a204f5fe72"`)
+}

--- a/minfraud/errors.go
+++ b/minfraud/errors.go
@@ -1,17 +1,59 @@
+// Copyright 2015-2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
 package minfraud
 
+// ErrorCode is a type that allows us to specify a const in our structs
+// that can then be translated to the API representationw when we marshal
+// the value to JSON.
 type ErrorCode int
 
 const (
+	// ErrUnknown is for unknown errors
 	ErrUnknown ErrorCode = iota
+
+	// ErrIPAddressInvalid is for when you have not supplied a valid
+	// IPv4 or IPv6 address.
 	ErrIPAddressInvalid
+
+	// ErrIPAddressRequired is for when you have not supplied an IP
+	// address, which is a required field.
 	ErrIPAddressRequired
+
+	// ErrIPAddressReserved is for when you have supplied an IP address
+	// which is reserved.
 	ErrIPAddressReserved
+
+	// ErrJSONInvalid is for when MaxMind cannot decode the body as a
+	// JSON object.
 	ErrJSONInvalid
+
+	// ErrAuthorizationInvalid is for when ou have supplied an invalid
+	// MaxMind user ID and/or license key in the Authorization header.
 	ErrAuthorizationInvalid
+
+	// ErrLicenseKeyRequired is for when you have not supplied a MaxMind
+	// license key in the Authorization header.
 	ErrLicenseKeyRequired
+
+	// ErrUserIDRequired is for when you have not supplied a MaxMind
+	// user ID in the Authorization header.
 	ErrUserIDRequired
+
+	// ErrInsufficientFunds is for when the license key you have provided
+	// does not have sufficient funds to use this service. Please purchase
+	// more service credits.
 	ErrInsufficientFunds
+
+	// ErrHTTPError is for when there is an HTTP related error. This includes
+	// 5XX level errors sent by MaxMind as well as an HTTP 415:
+	//
+	// Your request included a Content-Type header that is not supported. For
+	// GET requests, this means the web service cannot return content of that
+	// type. For PUT and POST queries, this means the web service cannot parse
+	// a request body of that type.
+	ErrHTTPError
 )
 
 // MarshalJSON implements the json.Marshaler interface.
@@ -33,35 +75,37 @@ func (e ErrorCode) MarshalJSON() ([]byte, error) {
 		return []byte(`"USER_ID_REQUIRED"`), nil
 	case ErrInsufficientFunds:
 		return []byte(`"INSUFFICIENT_FUNDS"`), nil
+	case ErrHTTPError:
+		return []byte(`""`), nil
 	default:
 		return []byte(`"UNKNOWN_ERROR"`), nil
 	}
 }
 
 // UnmarshalJSON implements the json.Unmarshaler interface.
-func (e ErrorCode) UnmarshalJSON(data []byte) (err error) {
+func (e *ErrorCode) UnmarshalJSON(data []byte) (err error) {
 	if len(data) < 3 {
-		e = ErrUnknown
+		*e = ErrUnknown
 	} else {
 		switch string(data[1 : len(data)-1]) {
 		case "IP_ADDRESS_INVALID":
-			e = ErrIPAddressInvalid
+			*e = ErrIPAddressInvalid
 		case "IP_ADDRESS_REQUIRED":
-			e = ErrIPAddressRequired
+			*e = ErrIPAddressRequired
 		case "IP_ADDRESS_RESERVED":
-			e = ErrIPAddressReserved
+			*e = ErrIPAddressReserved
 		case "JSON_INVALID":
-			e = ErrJSONInvalid
+			*e = ErrJSONInvalid
 		case "AUTHORIZATION_INVALID":
-			e = ErrAuthorizationInvalid
+			*e = ErrAuthorizationInvalid
 		case "LICENSE_KEY_REQUIRED":
-			e = ErrLicenseKeyRequired
+			*e = ErrLicenseKeyRequired
 		case "USER_ID_REQUIRED":
-			e = ErrUserIDRequired
+			*e = ErrUserIDRequired
 		case "INSUFFICIENT_FUNDS":
-			e = ErrInsufficientFunds
+			*e = ErrInsufficientFunds
 		default:
-			e = ErrUnknown
+			*e = ErrUnknown
 		}
 	}
 	return

--- a/minfraud/errors_test.go
+++ b/minfraud/errors_test.go
@@ -1,0 +1,126 @@
+// Copyright 2015-2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
+package minfraud_test
+
+import (
+	"github.com/theckman/go-maxmind/minfraud"
+	. "gopkg.in/check.v1"
+)
+
+func (t *TestSuite) TestErrCode_MarshalJSON(c *C) {
+	var ec minfraud.ErrorCode
+	var j []byte
+	var err error
+
+	ec = minfraud.ErrUnknown
+	j, err = ec.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"UNKNOWN_ERROR"`)
+
+	ec = minfraud.ErrIPAddressInvalid
+	j, err = ec.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"IP_ADDRESS_INVALID"`)
+
+	ec = minfraud.ErrIPAddressRequired
+	j, err = ec.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"IP_ADDRESS_REQUIRED"`)
+
+	ec = minfraud.ErrIPAddressReserved
+	j, err = ec.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"IP_ADDRESS_RESERVED"`)
+
+	ec = minfraud.ErrJSONInvalid
+	j, err = ec.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"JSON_INVALID"`)
+
+	ec = minfraud.ErrAuthorizationInvalid
+	j, err = ec.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"AUTHORIZATION_INVALID"`)
+
+	ec = minfraud.ErrLicenseKeyRequired
+	j, err = ec.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"LICENSE_KEY_REQUIRED"`)
+
+	ec = minfraud.ErrUserIDRequired
+	j, err = ec.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"USER_ID_REQUIRED"`)
+
+	ec = minfraud.ErrInsufficientFunds
+	j, err = ec.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"INSUFFICIENT_FUNDS"`)
+
+	ec = minfraud.ErrHTTPError
+	j, err = ec.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `""`)
+
+	ec++
+	j, err = ec.MarshalJSON()
+	c.Assert(err, IsNil)
+	c.Check(string(j), Equals, `"UNKNOWN_ERROR"`)
+}
+
+func (t *TestSuite) TestErrCode_UnmarshalJSON(c *C) {
+	var ec minfraud.ErrorCode
+	var err error
+
+	data := []byte(`""`)
+	err = ec.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ec, Equals, minfraud.ErrUnknown)
+
+	data = []byte(`"IP_ADDRESS_INVALID"`)
+	err = ec.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ec, Equals, minfraud.ErrIPAddressInvalid)
+
+	data = []byte(`"IP_ADDRESS_REQUIRED"`)
+	err = ec.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ec, Equals, minfraud.ErrIPAddressRequired)
+
+	data = []byte(`"IP_ADDRESS_RESERVED"`)
+	err = ec.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ec, Equals, minfraud.ErrIPAddressReserved)
+
+	data = []byte(`"JSON_INVALID"`)
+	err = ec.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ec, Equals, minfraud.ErrJSONInvalid)
+
+	data = []byte(`"AUTHORIZATION_INVALID"`)
+	err = ec.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ec, Equals, minfraud.ErrAuthorizationInvalid)
+
+	data = []byte(`"LICENSE_KEY_REQUIRED"`)
+	err = ec.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ec, Equals, minfraud.ErrLicenseKeyRequired)
+
+	data = []byte(`"USER_ID_REQUIRED"`)
+	err = ec.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ec, Equals, minfraud.ErrUserIDRequired)
+
+	data = []byte(`"INSUFFICIENT_FUNDS"`)
+	err = ec.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ec, Equals, minfraud.ErrInsufficientFunds)
+
+	data = []byte(`"UNKNOWN_ERROR"`)
+	err = ec.UnmarshalJSON(data)
+	c.Assert(err, IsNil)
+	c.Check(ec, Equals, minfraud.ErrUnknown)
+}

--- a/minfraud/minfraud.go
+++ b/minfraud/minfraud.go
@@ -1,1 +1,5 @@
+// Copyright 2015-2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
 package minfraud

--- a/minfraud/request_types.go
+++ b/minfraud/request_types.go
@@ -19,14 +19,14 @@ type Event struct {
 
 // Account contains account information for the end-user on the site where the event took place.
 type Account struct {
-	UserID      string `json:"user_id,omitempty"`
-	UsernamdMD5 string `json:"username_md5,omitempty"` // TODO: create an MD5Stringer type or something
+	UserID      string      `json:"user_id,omitempty"`
+	UsernamdMD5 MD5Stringer `json:"username_md5,omitempty"`
 }
 
 // Email contains information about an email address to include within the lookup.
 type Email struct {
-	AddressMD5 string `json:"address,omitempty"` // TODO: create an MD5Stringer type or something
-	Domain     string `json:"domain,omitempty"`
+	AddressMD5 MD5Stringer `json:"address,omitempty"`
+	Domain     string      `json:"domain,omitempty"`
 }
 
 // ContactDetails is a struct used for compositing. Both the Shipping and Billing types

--- a/minfraud/response_types.go
+++ b/minfraud/response_types.go
@@ -1,3 +1,7 @@
+// Copyright 2015-2016 Tim Heckman. All rights reserved.
+// Use of this source code is governed by the BSD 3-Clause
+// license that can be found in the LICENSE file.
+
 package minfraud
 
 type Warning struct {
@@ -24,7 +28,7 @@ type CreditCardResponse struct {
 	Issuer                          *Issuer `json:"issuer"`
 	Country                         string  `json:"country"`
 	IsIssuedInBillingAddressCountry bool    `json:"is_issued_in_billing_address_country"` // wowza
-	IsPrepaid                       bool    `json"is_prepaid"`
+	IsPrepaid                       bool    `json:"is_prepaid"`
 }
 
 type ShippingAddress struct {


### PR DESCRIPTION
This change adds some more testing and comments to the existing structs. In addition, it adds an `MD5Stringer` type which is a `string` with an `MD5()` method on it. The `MD5()` method returns the MD5 hash of the string itself.
